### PR TITLE
ethereumjs-testrpc has been renamed to ganache-cli

### DIFF
--- a/toolbox-docker/Dockerfile
+++ b/toolbox-docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM luongnguyen/oyente
 
-RUN npm install -g ethereumjs-testrpc
+RUN npm install -g ganache-cli
 
 RUN npm install -g truffle
 


### PR DESCRIPTION
As stated in the title. Nothing will break. 

More info can be found here: https://github.com/trufflesuite/ganache-cli/issues/432
